### PR TITLE
Do not log the API key

### DIFF
--- a/library/status_cake_ssl.py
+++ b/library/status_cake_ssl.py
@@ -65,7 +65,7 @@ class StatusCakeSSL:
 def main():
     fields = {
         "username": {"required": True, "type": "str"},
-        "api_key": {"required": True, "type": "str"},
+        "api_key": {"required": True, "type": "str", no_log=True},
         "domain": {"required": True, "type": "str"},
         "state": {"required": True, "choices": ['present', 'absent'], "type": "str"},
         "contact": {"required": True, "type": "int"},


### PR DESCRIPTION
To avoid ansible to show the API key after execution and in logs when outputs are kept.